### PR TITLE
LUN-3769: Use local instead of online minifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,31 +26,30 @@ VERSION = __import__(PACKAGE).__version__
 def getPkgPath():
     return __import__(PACKAGE).__path__[0] + '/'
 
-
 def minify(files, outfile, ftype):
-    import requests
+    """ using jsmin and cssmin, minify the list of javascript/css files, and write it in the outfile """
+    from jsmin import jsmin
+    from cssmin import cssmin
     import io
+    # make a dictionary to associate file types with the tool/function to minify it
+    tools = {
+        'js': jsmin,
+        'css': cssmin
+    }
 
+    # put all content from files in one variable
+    # minified files contents are separated by a newline
     content = ''
-
     for filename in files:
         with io.open(getPkgPath() + filename, 'r', encoding='utf8') as f:
-            content = content + '\n' + f.read()
+            content = content + '\n' + tools[ftype](f.read())
+    
+    # if any content was minified, write it to the output file
+    if content:
+        with  io.open(getPkgPath() + outfile, 'w', encoding='utf8') as f:
+            f.write(content)
 
-    data = {
-        'code': content,
-        'type': ftype,
-    }
-    response = requests.post('http://api.applegrew.com/minify', data)
-    response.raise_for_status()
-    response = response.json()
-    if response['success']:
-        with io.open(getPkgPath() + outfile, 'w', encoding='utf8') as f:
-            f.write(response['compiled_code'])
-    else:
-        raise Exception('%(error_code)s: "%(error)s"' % response)
-
-
+# this is the main thing that is run when setup.py is called with sdist to package django_select2
 if len(sys.argv) > 1 and 'sdist' in sys.argv[1:]:
     minify(['static/django_select2/js/select2.js'], 'static/django_select2/js/select2.min.js', 'js')
     minify(['static/django_select2/js/heavy_data.js'], 'static/django_select2/js/heavy_data.min.js', 'js')
@@ -107,7 +106,8 @@ setup(
         "Django>=1.3",
     ],
     setup_requires=[
-        "requests",
+        "jsmin",
+        "cssmin",
     ],
     zip_safe=False,
     cmdclass={'test': PyTest},

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,19 @@ def minify(files, outfile, ftype):
     # minified files contents are separated by a newline
     content = ''
     for filename in files:
-        with io.open(getPkgPath() + filename, 'r', encoding='utf8') as f:
-            content = content + '\n' + tools[ftype](f.read())
+        try:
+            file_content = ''
+            with io.open(getPkgPath() + filename, 'r', encoding='utf8') as f:
+                file_content = f.read()
+                content = '\n'.join([content, tools[ftype](file_content)])
+        except Exception as generic_exception:
+            if file_content: # if exception occured at compression/minification of file
+                print "Exception occurred: ({0}); file {1} not minified!".format(
+                    generic_exception, filename)
+                content = file_content # minified file has same content as original file
+            else:
+                print "Exception at reading of static file, re-raising ..."
+                raise generic_exception
     
     # if any content was minified, write it to the output file
     if content:


### PR DESCRIPTION
Used 2 python packages: jsmin for javascript and cssmin for css minify, removed requests package
Next: the Bamboo plan needs to be updated to install jsmin and cssmin instead of requests (which is no longer used)